### PR TITLE
docs: add discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,7 @@ After building, try out:
 or
 
 `echo aeiou | ./build/count_vowels.hermit.com`
+
+## Community
+
+Hermit shares the [Extism Discord](https://discord.gg/cx3usBCWnc). Join `#hermit` to discuss working with or building Hermit.


### PR DESCRIPTION
Added Community section to README. Discord link is the same as the one used for the Extism README. I can generate a new link if desired.