### PR TITLE
feat: build hermit with fast-jit wamr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: Install APE loader on Ubuntu
         if:   ${{ matrix.os == 'ubuntu-latest' }}

--- a/build_hermit.sh
+++ b/build_hermit.sh
@@ -3,5 +3,5 @@ export CC=x86_64-unknown-cosmo-cc
 export CXX=x86_64-unknown-cosmo-c++
 rm -rf build hermit-cli/build hermit-cli/target
 mkdir build
-cmake -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_FAST_INTERP=1 -B build
+cmake -DWAMR_BUILD_FAST_JIT=1 -B build
 cmake --build build -j


### PR DESCRIPTION
fast interp:
```
gavin@teleporter:~/dev/hermit$ time ./interp-hermit.com -f src/ubuntu/Hermitfile -o interp-ubuntu.hermit.com
{
  "MAP": [
    "/"
  ],
  "ENV_PWD_IS_HOST_CWD": true,
  "FROM": "src/ubuntu/ubuntu.wasm"
}
Unable to make "interp-ubuntu.hermit.com" executable!
Due to platform limitations you must do it yourself! Run:
chmod +x "interp-ubuntu.hermit.com"

real    1m20.106s
user    1m19.929s
sys     0m0.173s
```

fast jit:
```
gavin@teleporter:~/dev/hermit$ time ./fastjit-hermit.com -f src/ubuntu/Hermitfile -o fastjit-ubuntu.hermit.com
{
  "MAP": [
    "/"
  ],
  "ENV_PWD_IS_HOST_CWD": true,
  "FROM": "src/ubuntu/ubuntu.wasm"
}
Unable to make "fastjit-ubuntu.hermit.com" executable!
Due to platform limitations you must do it yourself! Run:
chmod +x "fastjit-ubuntu.hermit.com"

real    0m15.116s
user    0m15.142s
sys     0m0.383s
```